### PR TITLE
条件分岐にv4で廃止されたメソッドが使われていたので置換

### DIFF
--- a/Elements/contents_navi.php
+++ b/Elements/contents_navi.php
@@ -17,7 +17,7 @@
  * @lastmodified	$Date$
  * @license			http://basercms.net/license/index.html
  */
-if (!isset($this->BcPage) || !$this->BcPage->contentsNaviAvailable()) {
+if (isset($this->getPrevLink) && isset($this->getNextLink)) {
 	return;
 }
 ?>


### PR DESCRIPTION
v4で contentsNaviAvailable メソッドが廃止されており、デバッグモードでエラーが出たので修正しました。条件判定のロジックについてご確認くださいませ。